### PR TITLE
package.jsonのscripts中のでのパス指定修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "slack stream",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint lib/*.js bin/*",
-    "test": "npm run lint && ./node_modules/mocha/bin/mocha --require ./test/helper.js"
+    "lint": "eslint lib/*.js bin/*",
+    "test": "npm run lint && mocha --require ./test/helper.js"
   },
   "bin": {
     "slack-cli-stream": "bin/slack-cli-stream"


### PR DESCRIPTION
- scriptsタグ以下ではnode_modulesにパスが通った状態になるので省略します
