### PR TITLE
1メッセージが複数行に渡る場合、冒頭の数行のみ表示させる

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -117,6 +117,11 @@ core.start = (commander) => {
       }
     }
 
+    if (lines.length > 8) {
+      lines = lines.slice(0, 5);
+      lines.push("--- snip ---");
+    }
+
     lines.forEach((line) => {
       let l;
       l = emoji.emojify(line);


### PR DESCRIPTION
1メッセージが20行を超える様な場合一覧性の妨げになるので冒頭の5行のみ表示する様に修正します
