### PR TITLE
標準出力時の装飾対応

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -71,6 +71,8 @@ core.start = (commander) => {
     let time = moment(message.ts * 1000);
     let text = util.parseText(message);
 
+    text = util.decolateText(text);
+
     if (message.subtype) {
       switch(message.subtype) {
       case "message_deleted":

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -42,9 +42,11 @@ utility.decolateText = (message) => {
   // Bold
   let boldTexts = response.match(/\*(.+?)\*/g);
 
-  for (let i=0; i<boldTexts.length; i++) {
-    let text = boldTexts[i];
-    response = response.replace(boldTexts[i], chalk.bold(text.substring(1, text.length-1)));
+  if (boldTexts) {
+    for (let i=0; i<boldTexts.length; i++) {
+      let text = boldTexts[i];
+      response = response.replace(boldTexts[i], chalk.bold(text.substring(1, text.length-1)));
+    }
   }
 
   return response;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -51,7 +51,7 @@ utility.decolateText = (message) => {
 
   // quote (>)
   if (response.substring(0,4) == "&gt;") {
-    response = response.replace("&gt;", ">");
+    response = ">" + chalk.italic(response.substring(4));
   }
 
   return response;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -1,5 +1,7 @@
 let utility = {};
 
+let chalk = require("chalk");
+
 utility.users = {};
 utility.channels = {};
 utility.bots = {};
@@ -29,6 +31,20 @@ utility.parseText = (message) => {
     response = message.text || message.attachments[0].text;
   } catch(e) {
     // no operation
+  }
+
+  return response;
+};
+
+utility.decolateText = (message) => {
+  let response = message;
+
+  // Bold
+  let boldTexts = response.match(/\*(.+?)\*/g);
+
+  for (let i=0; i<boldTexts.length; i++) {
+    let text = boldTexts[i];
+    response = response.replace(boldTexts[i], chalk.bold(text.substring(1, text.length-1)));
   }
 
   return response;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -49,6 +49,11 @@ utility.decolateText = (message) => {
     }
   }
 
+  // quote (>)
+  if (response.substring(0,4) == "&gt;") {
+    response = response.replace("&gt;", ">");
+  }
+
   return response;
 };
 

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -40,3 +40,10 @@ describe("Slack messageのテキストパーサーのテスト", () => {
   });
 });
 
+describe("テキスト装飾のテスト", () => {
+  it("協調表記された文字が太文字になること", () => {
+    let expectedText = "Hello \u001b[1mworld\u001b[22m";
+
+    assert.equal(util.decolateText("Hello *world*"), expectedText, "worldという単語が太文字になっている");
+  });
+});

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -51,9 +51,9 @@ describe("テキスト装飾のテスト", () => {
     assert.equal(util.decolateText("Hello *world*"), expectedText, "worldという単語が太文字になっている");
   });
 
-  it("引用表記された文字が > になること", () => {
-    let expectedText = "> Hey";
+  it("引用表記された文字が > になり、以降イタリック表記されること", () => {
+    let expectedText = ">\u001b[3m Hey\u001b[23m";
 
-    assert.equal(util.decolateText("&gt; Hey"), expectedText, "Slack RTM APIから得られるエスケープされた引用符が > に置換されること");
+    assert.equal(util.decolateText("&gt; Hey"), expectedText);
   });
 });

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -41,9 +41,19 @@ describe("Slack messageのテキストパーサーのテスト", () => {
 });
 
 describe("テキスト装飾のテスト", () => {
+  it("装飾文字列が含まれない場合はそのままテキストが返ってくること", () => {
+    assert.equal(util.decolateText("Hello slack"), "Hello slack", "そのまま文字列が返ってくる");
+  });
+
   it("協調表記された文字が太文字になること", () => {
     let expectedText = "Hello \u001b[1mworld\u001b[22m";
 
     assert.equal(util.decolateText("Hello *world*"), expectedText, "worldという単語が太文字になっている");
+  });
+
+  it("引用表記された文字が > になること", () => {
+    let expectedText = "> Hey";
+
+    assert.equal(util.decolateText("&gt; Hey"), expectedText, "Slack RTM APIから得られるエスケープされた引用符が > に置換されること");
   });
 });


### PR DESCRIPTION
以下の標準出力時の対応を追加します

- Slack RTM API から引用符がエスケープされて返される際に引用符を `>` と置換して以後斜体表記
- `*keyword*` で協調表示されたものを太字で表示
