### PR TITLE
Slackメッセージ中の装飾タイミング修正

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -71,8 +71,6 @@ core.start = (commander) => {
     let time = moment(message.ts * 1000);
     let text = util.parseText(message);
 
-    text = util.decolateText(text);
-
     if (message.subtype) {
       switch(message.subtype) {
       case "message_deleted":
@@ -128,6 +126,7 @@ core.start = (commander) => {
       let l;
       l = emoji.emojify(line);
       l = util.replaceSlackId(l);
+      l = util.decolateText(l);
 
       console.log(
         "%s | %s | %s | %s",


### PR DESCRIPTION
複数行に渡って `>` を含む参照記述が行われた場合に文字装飾が複数行に渡ってしまう点を修正した