### PR TITLE
表示できるSlackメッセージのタイプ追加

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -96,6 +96,8 @@ core.start = (commander) => {
         break;
       case "pinned_item":
         break;
+      case "slackbot_response":
+        break;
       default:
         if (commander.debug) {
           logger.error(message);

--- a/lib/core.js
+++ b/lib/core.js
@@ -98,6 +98,8 @@ core.start = (commander) => {
         break;
       case "slackbot_response":
         break;
+      case "file_mention":
+        break;
       default:
         if (commander.debug) {
           logger.error(message);

--- a/lib/core.js
+++ b/lib/core.js
@@ -87,6 +87,8 @@ core.start = (commander) => {
         break;
       case "channel_leave":
         break;
+      case "group_leave":
+        break;
       case "reply_broadcast":
         return;
       case "file_comment":

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -27,10 +27,18 @@ utility.replaceSlackId = (line) => {
 utility.parseText = (message) => {
   let response = "";
 
-  try {
-    response = message.text || message.attachments[0].text;
-  } catch(e) {
-    // no operation
+  if (message.hasOwnProperty("text")) {
+    response = message.text;
+  }
+
+  if (response == "") {
+    if (message.hasOwnProperty("attachments")) {
+      if (message.attachments[0].hasOwnProperty("text")) {
+        response = message.attachments[0].text;
+      } else if (message.attachments[0].hasOwnProperty("pretext")) {
+        response = message.attachments[0].pretext;
+      }
+    }
   }
 
   return response;

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -21,6 +21,8 @@ describe("Slack ID置換のテスト", () => {
 });
 
 describe("Slack messageのテキストパーサーのテスト", () => {
+  let ghBotMessage = {"text":"","bot_id":"B5VPUMFGD","attachments":[{"fallback":"[foo/bar] Pull request submitted: .....","pretext":"[foo/bar] Pull request submitted by hideack","title":"#180 foobar","id":1,"title_link":"https://github.com/foo/bar/pull/180","color":"6CC644","mrkdwn_in":["text","pretext"]}],"type":"message","subtype":"bot_message","team":"T03GLB4LV","channel":"C03Q6TDDE","event_ts":"1498197665.915869","ts":"1498197665.915869","level":"error","message":"","timestamp":"2017-06-23T06:01:05.397Z"};
+
   let twitterBotMessage = {"bot_id":"XXE0S2FXX","attachments":[{"fallback":"<https://twitter.com/hideack@hideack>: Test message","ts":1495864801,"author_name":"hideack","author_link":"https://twitter.com/hideack/status/868346031640989696","author_icon":"https://pbs.twimg.com/profile_images/hideack/hideack_normal.png","author_subname":"@hideack","pretext":"<https://twitter.com/hideack/status/868346031640989696>","text":"Test message","service_name":"twitter","service_url":"https://twitter.com/","from_url":"https://twitter.com/hideack/status/868346031640989696","image_url":"https://pbs.twimg.com/media/DAv6DVjUIAAVlrY.jpg","image_width":1200,"image_height":800,"image_bytes":273940,"id":1,"footer":"Twitter","footer_icon":"https://a.slack-edge.com/6e067/img/services/twitter_pixel_snapped_32.png"}],"type":"message","subtype":"bot_message","team":"XX3GLB4XX","channel":"XXNQBEEXX","event_ts":"1495864803.324462","ts":"1495864803.324462","level":"error","message":"","timestamp":"2017-05-27T06:00:04.121Z"};
 
   let message = {type: 'message', channel: 'XXEGEXXS0', user: 'XX3NKUBXX', text: 'normal message', ts: '1495868089.515753',source_team: 'XXYGLB4ZZ', team: 'ZZ3GLB4XX' };
@@ -35,7 +37,11 @@ describe("Slack messageのテキストパーサーのテスト", () => {
     assert.equal(util.parseText(twitterBotMessage), "Test message", "botメッセージ中のattachmentsからtextが抽出できている");
   });
 
-  it("messageでtextが無く、attachmentsプロパティの中にtextも無い場合、空文字列が返ること", () => {
+  it("bot_messageでtextが無く、attachmentsプロパティの中にtextも無いがpretextがある場合、その部分をテキストとして抽出できること", () => {
+    assert.equal(util.parseText(ghBotMessage), "[foo/bar] Pull request submitted by hideack", "botメッセージ中のattachmentsからpretextが抽出できている");
+  });
+
+  it("messageでtextが無く、attachmentsプロパティの中にtext, pretextも無い場合、空文字列が返ること", () => {
     assert.equal(util.parseText(noTextMessage), "");
   });
 });


### PR DESCRIPTION
以下のメッセージタイプに新たに対応します

- Slackbotの返信のメッセージタイプ(slackbot_response, bot_message)追加及びbug-fix