### PR TITLE
コマンドラインオプションで渡せる設定をYAMLで設定できる様にする

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -22,6 +22,7 @@ let core = {};
 
 core.start = (commander) => {
   let logger;
+  let token = commander.token;
 
   if (commander.debug) {
     logger = getLogger(commander.debug);
@@ -29,9 +30,12 @@ core.start = (commander) => {
 
   if (commander.settings) {
     util.parseSettingFile(commander.settings);
+
+    if (util.token) {
+      token = util.token;
+    }
   }
 
-  let token = commander.token;
   let slack = require("@slack/client");
   let RtmClient = slack.RtmClient;
 

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -8,6 +8,7 @@ utility.users = {};
 utility.channels = {};
 utility.bots = {};
 utility.keywords = [];
+utility.token = "";
 
 utility.replaceSlackId = (line) => {
   let res = line;
@@ -63,6 +64,10 @@ utility.parseSettingFile = (path) => {
 
   if (settings.keywords) {
     utility.keywords = settings.keywords;
+  }
+
+  if (settings.token) {
+    utility.token = settings.token;
   }
 };
 

--- a/test/settings_sample.yaml
+++ b/test/settings_sample.yaml
@@ -1,3 +1,5 @@
 keywords:
   - abc
   - xyz
+token:
+  - xoxp-xxxx-xxxx-xxxx-xxxx

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -79,5 +79,6 @@ describe("設定ファイル読み込みのテスト", () => {
   it("設定ファイルを読み込み強調キーワードが更新されていること", () => {
     util.parseSettingFile('./test/settings_sample.yaml');
     assert.deepEqual(util.keywords, ["abc", "xyz"], "キーワードが設定ファイルに基いて更新されている");
+    assert.equal(util.token, "xoxp-xxxx-xxxx-xxxx-xxxx", "Slackのトークン文字列が更新されている");
   });
 });


### PR DESCRIPTION
- 現状コマンドラインオプションで渡しているSlackのトークン情報等を設定ファイル経由で渡せる様にします