### PR TITLE
プライベートチャンネルの一覧取得を追加

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -270,6 +270,13 @@ core.start = (commander) => {
       util.channels[v.id] = v;
     });
 
+    return web.groups.list();
+  }).then((response) => {
+    response.groups.forEach((v, i) => {
+      v.color = colors[i % colors.length];
+      util.channels[v.id] = v;
+    });
+
     // [pending] bots list
     //return web.bots.info();
   }).then(() => {


### PR DESCRIPTION
https://api.slack.com/events/message.groups を利用してプライベートチャンネルの一覧も取得する様にします