### PR TITLE
Deprecating early methods in favor of the Conversations API の対応

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -8,6 +8,7 @@ let cli = require("./cli.js");
 let twitter = require("twitter");
 
 const exec = require("child_process").exec;
+const MAXIMUM_CH = 5000;
 
 let getLogger = (path) => {
   let settings = {
@@ -263,16 +264,10 @@ core.start = (commander) => {
       util.users[v.id] = v;
     });
 
-    return web.channels.list();
+    return web.conversations.list({limit: MAXIMUM_CH});
   }).then((response) => {
-    response.channels.forEach((v, i) => {
-      v.color = colors[i % colors.length];
-      util.channels[v.id] = v;
-    });
 
-    return web.groups.list();
-  }).then((response) => {
-    response.groups.forEach((v, i) => {
+    response.channels.forEach((v, i) => {
       v.color = colors[i % colors.length];
       util.channels[v.id] = v;
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-cli-stream",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "slack stream",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
ref: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api