### PR TITLE
Slackメタデータの定期更新を追加し間隔を設定可能にする

### DIFF
--- a/bin/slack-cli-stream
+++ b/bin/slack-cli-stream
@@ -21,6 +21,7 @@ program
   .option("-h, --hook", "Enable realtime messaging hook.")
   .option("-l, --log <path>", "Specify the log file path")
   .option("--no-log", "Do not record logs")
+  .option("--refresh-interval <minutes>", "Refresh Slack metadata interval in minutes (default: 15)")
   .usage("[options] <parameters>")
   .parse(process.argv);
 
@@ -31,4 +32,3 @@ if (program.rawArgs.length == 2) {
 }
 
 core.start(program);
-

--- a/lib/core.js
+++ b/lib/core.js
@@ -422,59 +422,75 @@ core.start = async (commander) => {
   const {WebClient} = require("@slack/client");
   const web = new WebClient(token, {logLevel: "error"});
 
-  let response = await web.conversations.list({
-    limit:1000,
-    types: "public_channel,private_channel,im,mpim"
-  });
-
-  response.channels.forEach((v, i) => {
-    v.color = colors[i % colors.length];
-    util.channels[v.id] = v;
-  });
-
-  while(response.response_metadata.next_cursor != "") {
-    response = await web.conversations.list({
-      limit: 1000,
-      types: "public_channel,private_channel,im,mpim",
-      cursor: response.response_metadata.next_cursor
-    });
-
-    response.channels.forEach((v, i) => {
-      v.color = colors[i % colors.length];
-      util.channels[v.id] = v;
-    });
-  }
-
-  response = await web.users.list();
-  
-  if (response.members && Array.isArray(response.members)) {
-    response.members.forEach((v, i) => {
-      v.color = colors[i % colors.length];
-      // nameプロパティが存在しない場合の代替案を追加
-      if (!v.name) {
-        v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
-      }
-      util.users[v.id] = v;
-    });
-  }
-
-  while(response.response_metadata && response.response_metadata.next_cursor != "") {
-    response = await web.users.list({
-      limit: 1000,
-      cursor: response.response_metadata.next_cursor
-    });
-
-    if (response.members && Array.isArray(response.members)) {
-      response.members.forEach((v, i) => {
-        v.color = colors[i % colors.length];
-        // nameプロパティが存在しない場合の代替案を追加
-        if (!v.name) {
-          v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
-        }
-        util.users[v.id] = v;
-      });
+  let isRefreshing = false;
+  const refreshSlackData = async () => {
+    if (isRefreshing) {
+      return;
     }
-  }
+    isRefreshing = true;
+    try {
+      let response = await web.conversations.list({
+        limit:1000,
+        types: "public_channel,private_channel,im,mpim"
+      });
+
+      response.channels.forEach((v, i) => {
+        v.color = colors[i % colors.length];
+        util.channels[v.id] = v;
+      });
+
+      while(response.response_metadata.next_cursor != "") {
+        response = await web.conversations.list({
+          limit: 1000,
+          types: "public_channel,private_channel,im,mpim",
+          cursor: response.response_metadata.next_cursor
+        });
+
+        response.channels.forEach((v, i) => {
+          v.color = colors[i % colors.length];
+          util.channels[v.id] = v;
+        });
+      }
+
+      response = await web.users.list();
+      
+      if (response.members && Array.isArray(response.members)) {
+        response.members.forEach((v, i) => {
+          v.color = colors[i % colors.length];
+          // nameプロパティが存在しない場合の代替案を追加
+          if (!v.name) {
+            v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
+          }
+          util.users[v.id] = v;
+        });
+      }
+
+      while(response.response_metadata && response.response_metadata.next_cursor != "") {
+        response = await web.users.list({
+          limit: 1000,
+          cursor: response.response_metadata.next_cursor
+        });
+
+        if (response.members && Array.isArray(response.members)) {
+          response.members.forEach((v, i) => {
+            v.color = colors[i % colors.length];
+            // nameプロパティが存在しない場合の代替案を追加
+            if (!v.name) {
+              v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
+            }
+            util.users[v.id] = v;
+          });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to refresh Slack metadata:", error.message || error);
+    } finally {
+      isRefreshing = false;
+    }
+  };
+
+  await refreshSlackData();
+  setInterval(refreshSlackData, 15 * 60 * 1000);
 
   // complete 
   rtm.start();

--- a/lib/core.js
+++ b/lib/core.js
@@ -423,6 +423,10 @@ core.start = async (commander) => {
   const web = new WebClient(token, {logLevel: "error"});
 
   let isRefreshing = false;
+  let refreshIntervalMinutes = parseInt(options.refreshInterval, 10);
+  if (!Number.isFinite(refreshIntervalMinutes) || refreshIntervalMinutes <= 0) {
+    refreshIntervalMinutes = 15;
+  }
   const refreshSlackData = async () => {
     if (isRefreshing) {
       return;
@@ -490,7 +494,7 @@ core.start = async (commander) => {
   };
 
   await refreshSlackData();
-  setInterval(refreshSlackData, 15 * 60 * 1000);
+  setInterval(refreshSlackData, refreshIntervalMinutes * 60 * 1000);
 
   // complete 
   rtm.start();


### PR DESCRIPTION
- チャンネル/ユーザーのメタデータ取得を定期実行するよう整理
- 重複実行を防ぐガードと、失敗時のログ出力を追加
- --refresh-interval <minutes> で更新間隔を指定可能（不正値は15分にフォールバック）
