### PR TITLE
Add lock icon prefix for private channels

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -76,7 +76,8 @@ let resolveChannelLabelDisplay = (channelId) => {
   }
 
   if (channel.name) {
-    return "#" + chalk[channel.color](name);
+    const prefix = channel.is_private ? "🔐#" : "#";
+    return prefix + chalk[channel.color](name);
   }
 
   return chalk.white(name || "-");


### PR DESCRIPTION
Show 🔐 before # for private channels to visually distinguish them from public channels.