### PR TITLE
Add SQLite logging support via --log-sqlite option

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 15.x]
+        node-version: [20.x, 22.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:

--- a/bin/slack-cli-stream
+++ b/bin/slack-cli-stream
@@ -21,6 +21,7 @@ program
   .option("-h, --hook", "Enable realtime messaging hook.")
   .option("-l, --log <path>", "Specify the log file path")
   .option("--no-log", "Do not record logs")
+  .option("--log-sqlite <path>", "Specify the SQLite database file path for logging")
   .option("--refresh-interval <minutes>", "Refresh Slack metadata interval in minutes (default: 15)")
   .usage("[options] <parameters>")
   .parse(process.argv);

--- a/lib/core.js
+++ b/lib/core.js
@@ -156,7 +156,17 @@ core.display = (data, options)  => {
         logMessage(options.log, plainDateFormat, plainChannel, plainName, plainLine);
       }
       if (options.logSqlite && sqliteDb) {
-        logMessageSqlite(sqliteDb, plainDateFormat, plainChannel, plainName, plainLine);
+        logMessageSqlite(
+          sqliteDb,
+          plainDateFormat,
+          plainChannel,
+          plainName,
+          plainLine,
+          data.channel  || null,
+          data.user     || null,
+          data.slackTs  || null,
+          data.threadTs || null
+        );
       }
     }
 
@@ -403,7 +413,9 @@ core.start = async (commander) => {
       lines: lines,
       time: time,
       channel: message.channel,
-      user: message.user
+      user: message.user,
+      slackTs: message.ts || null,
+      threadTs: message.thread_ts || null
     };
 
     util.addMessageBuffer(data);

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,6 +10,32 @@ let twitter = require("twitter");
 const path = require("path");
 const fs = require("fs");
 const exec = require("child_process").exec;
+const Database = require("better-sqlite3");
+
+let sqliteDb = null;
+
+const initSqliteDb = (dbPath) => {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      logged_at  TEXT NOT NULL,
+      channel    TEXT,
+      user       TEXT,
+      message    TEXT,
+      created_at TEXT DEFAULT (datetime('now', 'localtime'))
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_logged_at ON messages (logged_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_channel   ON messages (channel)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_user      ON messages (user)");
+  return db;
+};
+
+const logMessageSqlite = (db, time, channel, user, message) => {
+  const stmt = db.prepare("INSERT INTO messages (logged_at, channel, user, message) VALUES (?, ?, ?, ?)");
+  stmt.run(time, channel, user, message);
+};
 
 let getLogger = (path) => {
   let settings = {
@@ -143,12 +169,18 @@ core.display = (data, options)  => {
       l
     );
 
-    if (options.log) {
+    if (options.log || options.logSqlite) {
       const plainDateFormat = removeEscapeSequences(dateFormat);
       const plainChannel = removeEscapeSequences(channel);
       const plainName = removeEscapeSequences(name);
       const plainLine = removeEscapeSequences(l);
-      logMessage(options.log, plainDateFormat, plainChannel, plainName, plainLine);
+
+      if (options.log) {
+        logMessage(options.log, plainDateFormat, plainChannel, plainName, plainLine);
+      }
+      if (options.logSqlite && sqliteDb) {
+        logMessageSqlite(sqliteDb, plainDateFormat, plainChannel, plainName, plainLine);
+      }
     }
 
     name = chalk.white("|>");
@@ -163,6 +195,10 @@ core.start = async (commander) => {
 
   if (options.debug) {
     logger = getLogger(options.debug);
+  }
+
+  if (options.logSqlite) {
+    sqliteDb = initSqliteDb(options.logSqlite);
   }
 
   if (options.settings) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,32 +10,9 @@ let twitter = require("twitter");
 const path = require("path");
 const fs = require("fs");
 const exec = require("child_process").exec;
-const Database = require("better-sqlite3");
+const { initSqliteDb, logMessageSqlite } = require("./sqlite-logger");
 
 let sqliteDb = null;
-
-const initSqliteDb = (dbPath) => {
-  const db = new Database(dbPath);
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS messages (
-      id         INTEGER PRIMARY KEY AUTOINCREMENT,
-      logged_at  TEXT NOT NULL,
-      channel    TEXT,
-      user       TEXT,
-      message    TEXT,
-      created_at TEXT DEFAULT (datetime('now', 'localtime'))
-    )
-  `);
-  db.exec("CREATE INDEX IF NOT EXISTS idx_logged_at ON messages (logged_at)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_channel   ON messages (channel)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_user      ON messages (user)");
-  return db;
-};
-
-const logMessageSqlite = (db, time, channel, user, message) => {
-  const stmt = db.prepare("INSERT INTO messages (logged_at, channel, user, message) VALUES (?, ?, ?, ?)");
-  stmt.run(time, channel, user, message);
-};
 
 let getLogger = (path) => {
   let settings = {

--- a/lib/sqlite-logger.js
+++ b/lib/sqlite-logger.js
@@ -1,0 +1,26 @@
+const Database = require("better-sqlite3");
+
+const initSqliteDb = (dbPath) => {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS messages (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      logged_at  TEXT NOT NULL,
+      channel    TEXT,
+      user       TEXT,
+      message    TEXT,
+      created_at TEXT DEFAULT (datetime('now', 'localtime'))
+    )
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_logged_at ON messages (logged_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_channel   ON messages (channel)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_user      ON messages (user)");
+  return db;
+};
+
+const logMessageSqlite = (db, time, channel, user, message) => {
+  const stmt = db.prepare("INSERT INTO messages (logged_at, channel, user, message) VALUES (?, ?, ?, ?)");
+  stmt.run(time, channel, user, message);
+};
+
+module.exports = { initSqliteDb, logMessageSqlite };

--- a/lib/sqlite-logger.js
+++ b/lib/sqlite-logger.js
@@ -9,18 +9,48 @@ const initSqliteDb = (dbPath) => {
       channel    TEXT,
       user       TEXT,
       message    TEXT,
+      channel_id TEXT,
+      user_id    TEXT,
+      slack_ts   TEXT,
+      thread_ts  TEXT,
       created_at TEXT DEFAULT (datetime('now', 'localtime'))
     )
   `);
-  db.exec("CREATE INDEX IF NOT EXISTS idx_logged_at ON messages (logged_at)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_channel   ON messages (channel)");
-  db.exec("CREATE INDEX IF NOT EXISTS idx_user      ON messages (user)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_logged_at  ON messages (logged_at)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_channel    ON messages (channel)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_user       ON messages (user)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_slack_ts   ON messages (slack_ts)");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_thread_ts  ON messages (thread_ts)");
+
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts
+    USING fts5(message, content='messages', content_rowid='id')
+  `);
+  db.exec(`
+    CREATE TRIGGER IF NOT EXISTS messages_fts_insert
+    AFTER INSERT ON messages BEGIN
+      INSERT INTO messages_fts(rowid, message) VALUES (new.id, new.message);
+    END
+  `);
+
   return db;
 };
 
-const logMessageSqlite = (db, time, channel, user, message) => {
-  const stmt = db.prepare("INSERT INTO messages (logged_at, channel, user, message) VALUES (?, ?, ?, ?)");
-  stmt.run(time, channel, user, message);
+const logMessageSqlite = (db, time, channel, user, message, channelId, userId, slackTs, threadTs) => {
+  const stmt = db.prepare(`
+    INSERT INTO messages (logged_at, channel, user, message, channel_id, user_id, slack_ts, thread_ts)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+  stmt.run(
+    time,
+    channel,
+    user,
+    message,
+    channelId  || null,
+    userId     || null,
+    slackTs    || null,
+    threadTs   || null
+  );
 };
 
 module.exports = { initSqliteDb, logMessageSqlite };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@slack/client": "^4.12.0",
         "@slack/rtm-api": "^7.0.4",
+        "better-sqlite3": "^12.8.0",
         "chalk": "^4.1.2",
         "commander": "10.0.0",
         "cron-parser": "^4.7.1",
@@ -657,6 +658,40 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -664,6 +699,26 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -695,6 +750,30 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -832,6 +911,12 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -1052,6 +1137,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -1062,6 +1162,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -1129,6 +1238,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -1174,6 +1292,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
@@ -1513,6 +1640,15 @@
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
       "license": "MIT"
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1561,6 +1697,12 @@
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
       }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
@@ -1680,6 +1822,12 @@
       "engines": {
         "node": ">= 0.12"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1810,6 +1958,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -1986,6 +2140,26 @@
       "bin": {
         "he": "bin/he"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.2.4",
@@ -2689,6 +2863,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2701,6 +2887,15 @@
         "node": "*"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mixme": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
@@ -2708,6 +2903,12 @@
       "engines": {
         "node": ">= 8.0.0"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mocha": {
       "version": "10.8.2",
@@ -2818,6 +3019,12 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -2836,6 +3043,18 @@
       },
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-emoji": {
@@ -2960,7 +3179,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -3179,6 +3397,33 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3193,6 +3438,16 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -3231,6 +3486,36 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/readable-stream": {
@@ -3469,6 +3754,18 @@
       "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -3630,6 +3927,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -3775,6 +4117,34 @@
         "node": ">=8"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -3811,6 +4181,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6.x"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/twitter": {
@@ -4159,8 +4541,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -4709,11 +5090,43 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.12",
@@ -4739,6 +5152,15 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "call-bind": {
       "version": "1.0.8",
@@ -4826,6 +5248,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -4989,6 +5416,14 @@
       "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
       "dev": true
     },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
     "deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -4997,6 +5432,11 @@
       "requires": {
         "type-detect": "^4.0.0"
       }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -5042,6 +5482,11 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
+    "detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="
+    },
     "diff": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
@@ -5076,6 +5521,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
+    "end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "es-abstract": {
       "version": "1.24.0",
@@ -5330,6 +5783,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5375,6 +5833,11 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "fill-range": {
       "version": "7.1.1",
@@ -5452,6 +5915,11 @@
         "mime-types": "^2.1.35",
         "safe-buffer": "^5.2.1"
       }
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -5535,6 +6003,11 @@
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.2.0",
@@ -5640,6 +6113,11 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.4",
@@ -6083,6 +6561,11 @@
         "mime-db": "1.52.0"
       }
     },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -6092,10 +6575,20 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
+    },
     "mixme": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.4.tgz",
       "integrity": "sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw=="
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "mocha": {
       "version": "10.8.2",
@@ -6177,6 +6670,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6192,6 +6690,14 @@
         "ini": "^2.0.0",
         "secure-keys": "^1.0.0",
         "yargs": "^16.1.1"
+      }
+    },
+    "node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "requires": {
+        "semver": "^7.3.5"
       }
     },
     "node-emoji": {
@@ -6276,7 +6782,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -6426,6 +6931,25 @@
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
       "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="
     },
+    "prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6436,6 +6960,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
+    "pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -6456,6 +6989,29 @@
       "dev": true,
       "requires": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "ini": {
+          "version": "1.3.8",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+          "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+        }
       }
     },
     "readable-stream": {
@@ -6597,6 +7153,11 @@
       "resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
       "integrity": "sha1-8MgtmKOxOah3aogIBQuCRDEIf8o="
     },
+    "semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="
+    },
     "serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -6708,6 +7269,21 @@
         "side-channel-map": "^1.0.1"
       }
     },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
@@ -6810,6 +7386,29 @@
         "has-flag": "^4.0.0"
       }
     },
+    "tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
     "text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -6839,6 +7438,14 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
       "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "twitter": {
       "version": "1.1.0",
@@ -7084,8 +7691,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
       "version": "8.18.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@slack/client": "^4.12.0",
     "@slack/rtm-api": "^7.0.4",
+    "better-sqlite3": "^12.8.0",
     "chalk": "^4.1.2",
     "commander": "10.0.0",
     "cron-parser": "^4.7.1",

--- a/test/sqlite_logger_test.js
+++ b/test/sqlite_logger_test.js
@@ -32,25 +32,53 @@ describe("SQLiteロガーのテスト", () => {
       assert.equal(row.name, "messages", "messagesテーブルが存在する");
     });
 
+    it("messages_fts仮想テーブルが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='messages_fts'"
+      ).get();
+      assert.equal(row.name, "messages_fts", "messages_fts仮想テーブルが存在する");
+    });
+
+    it("messages_fts_insertトリガーが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='trigger' AND name='messages_fts_insert'"
+      ).get();
+      assert.equal(row.name, "messages_fts_insert", "messages_fts_insertトリガーが存在する");
+    });
+
     it("logged_atインデックスが作成されること", () => {
       const row = db.prepare(
         "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_logged_at'"
       ).get();
-      assert.equal(row.name, "idx_logged_at", "idx_logged_atインデックスが存在する");
+      assert.equal(row.name, "idx_logged_at");
     });
 
     it("channelインデックスが作成されること", () => {
       const row = db.prepare(
         "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_channel'"
       ).get();
-      assert.equal(row.name, "idx_channel", "idx_channelインデックスが存在する");
+      assert.equal(row.name, "idx_channel");
     });
 
     it("userインデックスが作成されること", () => {
       const row = db.prepare(
         "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_user'"
       ).get();
-      assert.equal(row.name, "idx_user", "idx_userインデックスが存在する");
+      assert.equal(row.name, "idx_user");
+    });
+
+    it("slack_tsインデックスが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_slack_ts'"
+      ).get();
+      assert.equal(row.name, "idx_slack_ts");
+    });
+
+    it("thread_tsインデックスが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_thread_ts'"
+      ).get();
+      assert.equal(row.name, "idx_thread_ts");
     });
 
     it("既存DBに対して再度initしてもエラーにならないこと", () => {
@@ -63,53 +91,95 @@ describe("SQLiteロガーのテスト", () => {
 
   describe("logMessageSqlite", () => {
     it("メッセージが1件INSERTされること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello", "C0123", "U0456", "1234567890.000100", null);
       const rows = db.prepare("SELECT * FROM messages").all();
       assert.equal(rows.length, 1, "1件のレコードが存在する");
     });
 
     it("INSERTしたメッセージの各フィールドが正しく保存されること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello", "C0123", "U0456", "1234567890.000100", null);
       const row = db.prepare("SELECT * FROM messages").get();
-      assert.equal(row.logged_at, "2026-04-05 12:00:00", "logged_atが一致する");
-      assert.equal(row.channel,   "#general",             "channelが一致する");
-      assert.equal(row.user,      "alice",                "userが一致する");
-      assert.equal(row.message,   "Hello",                "messageが一致する");
+      assert.equal(row.logged_at,  "2026-04-05 12:00:00",   "logged_atが一致する");
+      assert.equal(row.channel,    "#general",               "channelが一致する");
+      assert.equal(row.user,       "alice",                  "userが一致する");
+      assert.equal(row.message,    "Hello",                  "messageが一致する");
+      assert.equal(row.channel_id, "C0123",                  "channel_idが一致する");
+      assert.equal(row.user_id,    "U0456",                  "user_idが一致する");
+      assert.equal(row.slack_ts,   "1234567890.000100",      "slack_tsが一致する");
+      assert.isNull(row.thread_ts,                           "thread_tsがnull");
+    });
+
+    it("スレッドメッセージのthread_tsが保存されること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Reply", "C0123", "U0456", "1234567891.000200", "1234567890.000100");
+      const row = db.prepare("SELECT thread_ts FROM messages").get();
+      assert.equal(row.thread_ts, "1234567890.000100", "thread_tsが一致する");
     });
 
     it("複数件のメッセージをINSERTできること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
-      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "bob",   "Hi");
-      logMessageSqlite(db, "2026-04-05 12:00:02", "#random",  "alice", "Hey");
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello",   "C0001", "U0001", "100.000", null);
+      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "bob",   "Hi",      "C0001", "U0002", "101.000", null);
+      logMessageSqlite(db, "2026-04-05 12:00:02", "#random",  "alice", "Hey",     "C0002", "U0001", "102.000", null);
       const rows = db.prepare("SELECT * FROM messages").all();
       assert.equal(rows.length, 3, "3件のレコードが存在する");
     });
 
     it("idがAUTOINCREMENTで連番になること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "first");
-      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "alice", "second");
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "first",  "C0001", "U0001", "100.000", null);
+      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "alice", "second", "C0001", "U0001", "101.000", null);
       const rows = db.prepare("SELECT id FROM messages ORDER BY id").all();
       assert.equal(rows[0].id, 1, "1件目のidは1");
       assert.equal(rows[1].id, 2, "2件目のidは2");
     });
 
     it("created_atが自動セットされること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello", "C0001", "U0001", "100.000", null);
       const row = db.prepare("SELECT created_at FROM messages").get();
-      assert.isString(row.created_at, "created_atが文字列として存在する");
+      assert.isString(row.created_at,   "created_atが文字列として存在する");
       assert.isNotEmpty(row.created_at, "created_atが空でない");
     });
 
     it("日本語メッセージが正しく保存されること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "こんにちは世界");
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "こんにちは世界", "C0001", "U0001", "100.000", null);
       const row = db.prepare("SELECT message FROM messages").get();
       assert.equal(row.message, "こんにちは世界", "日本語メッセージが一致する");
     });
 
     it("channelがnullでもINSERTできること", () => {
-      logMessageSqlite(db, "2026-04-05 12:00:00", null, "alice", "Hello");
+      logMessageSqlite(db, "2026-04-05 12:00:00", null, "alice", "Hello", null, "U0001", "100.000", null);
       const row = db.prepare("SELECT * FROM messages").get();
-      assert.isNull(row.channel, "channelがnull");
+      assert.isNull(row.channel,    "channelがnull");
+      assert.isNull(row.channel_id, "channel_idがnull");
+    });
+  });
+
+  describe("FTS5全文検索のテスト", () => {
+    beforeEach(() => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello world",       "C0001", "U0001", "100.000", null);
+      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "bob",   "Good morning",      "C0001", "U0002", "101.000", null);
+      logMessageSqlite(db, "2026-04-05 12:00:02", "#random",  "alice", "こんにちは世界",    "C0002", "U0001", "102.000", null);
+    });
+
+    it("FTS5でキーワード検索できること", () => {
+      const rows = db.prepare(
+        "SELECT m.* FROM messages m JOIN messages_fts f ON m.id = f.rowid WHERE messages_fts MATCH ?"
+      ).all("Hello");
+      assert.equal(rows.length, 1, "1件ヒットする");
+      assert.equal(rows[0].message, "Hello world", "メッセージが一致する");
+    });
+
+    it("FTS5で日本語キーワード検索できること", () => {
+      const rows = db.prepare(
+        "SELECT m.* FROM messages m JOIN messages_fts f ON m.id = f.rowid WHERE messages_fts MATCH ?"
+      ).all("こんにちは世界");
+      assert.equal(rows.length, 1, "1件ヒットする");
+      assert.equal(rows[0].message, "こんにちは世界", "日本語メッセージが一致する");
+    });
+
+    it("FTS5で存在しないキーワードは0件になること", () => {
+      const rows = db.prepare(
+        "SELECT m.* FROM messages m JOIN messages_fts f ON m.id = f.rowid WHERE messages_fts MATCH ?"
+      ).all("notexist");
+      assert.equal(rows.length, 0, "0件ヒットする");
     });
   });
 });

--- a/test/sqlite_logger_test.js
+++ b/test/sqlite_logger_test.js
@@ -1,0 +1,115 @@
+let assert = require("chai").assert;
+let fs = require("fs");
+let os = require("os");
+let path = require("path");
+let { initSqliteDb, logMessageSqlite } = require("../lib/sqlite-logger");
+
+describe("SQLiteロガーのテスト", () => {
+  let db;
+  let dbPath;
+
+  beforeEach(() => {
+    dbPath = path.join(os.tmpdir(), `slack-test-${Date.now()}.db`);
+    db = initSqliteDb(dbPath);
+  });
+
+  afterEach(() => {
+    db.close();
+    if (fs.existsSync(dbPath)) {
+      fs.unlinkSync(dbPath);
+    }
+  });
+
+  describe("initSqliteDb", () => {
+    it("DBファイルが作成されること", () => {
+      assert.isTrue(fs.existsSync(dbPath), "DBファイルが存在する");
+    });
+
+    it("messagesテーブルが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='messages'"
+      ).get();
+      assert.equal(row.name, "messages", "messagesテーブルが存在する");
+    });
+
+    it("logged_atインデックスが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_logged_at'"
+      ).get();
+      assert.equal(row.name, "idx_logged_at", "idx_logged_atインデックスが存在する");
+    });
+
+    it("channelインデックスが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_channel'"
+      ).get();
+      assert.equal(row.name, "idx_channel", "idx_channelインデックスが存在する");
+    });
+
+    it("userインデックスが作成されること", () => {
+      const row = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_user'"
+      ).get();
+      assert.equal(row.name, "idx_user", "idx_userインデックスが存在する");
+    });
+
+    it("既存DBに対して再度initしてもエラーにならないこと", () => {
+      assert.doesNotThrow(() => {
+        const db2 = initSqliteDb(dbPath);
+        db2.close();
+      });
+    });
+  });
+
+  describe("logMessageSqlite", () => {
+    it("メッセージが1件INSERTされること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      const rows = db.prepare("SELECT * FROM messages").all();
+      assert.equal(rows.length, 1, "1件のレコードが存在する");
+    });
+
+    it("INSERTしたメッセージの各フィールドが正しく保存されること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      const row = db.prepare("SELECT * FROM messages").get();
+      assert.equal(row.logged_at, "2026-04-05 12:00:00", "logged_atが一致する");
+      assert.equal(row.channel,   "#general",             "channelが一致する");
+      assert.equal(row.user,      "alice",                "userが一致する");
+      assert.equal(row.message,   "Hello",                "messageが一致する");
+    });
+
+    it("複数件のメッセージをINSERTできること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "bob",   "Hi");
+      logMessageSqlite(db, "2026-04-05 12:00:02", "#random",  "alice", "Hey");
+      const rows = db.prepare("SELECT * FROM messages").all();
+      assert.equal(rows.length, 3, "3件のレコードが存在する");
+    });
+
+    it("idがAUTOINCREMENTで連番になること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "first");
+      logMessageSqlite(db, "2026-04-05 12:00:01", "#general", "alice", "second");
+      const rows = db.prepare("SELECT id FROM messages ORDER BY id").all();
+      assert.equal(rows[0].id, 1, "1件目のidは1");
+      assert.equal(rows[1].id, 2, "2件目のidは2");
+    });
+
+    it("created_atが自動セットされること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "Hello");
+      const row = db.prepare("SELECT created_at FROM messages").get();
+      assert.isString(row.created_at, "created_atが文字列として存在する");
+      assert.isNotEmpty(row.created_at, "created_atが空でない");
+    });
+
+    it("日本語メッセージが正しく保存されること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", "#general", "alice", "こんにちは世界");
+      const row = db.prepare("SELECT message FROM messages").get();
+      assert.equal(row.message, "こんにちは世界", "日本語メッセージが一致する");
+    });
+
+    it("channelがnullでもINSERTできること", () => {
+      logMessageSqlite(db, "2026-04-05 12:00:00", null, "alice", "Hello");
+      const row = db.prepare("SELECT * FROM messages").get();
+      assert.isNull(row.channel, "channelがnull");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- `--log-sqlite <path>` オプションを追加し、Slackメッセージをローカルの SQLite DB に記録できるようにした
- 既存の TSV ファイルログ (`-l`) と併用可能
- 将来の MCP 接続を見据え、Slack 生ID・スレッド情報・FTS5 全文検索インデックスを含む設計にした

## テーブルスキーマ

```sql
CREATE TABLE messages (
  id         INTEGER PRIMARY KEY AUTOINCREMENT,
  logged_at  TEXT NOT NULL,       -- 表示用時刻
  channel    TEXT,                -- 表示用チャンネル名 (#general 等)
  user       TEXT,                -- 表示用ユーザー名
  message    TEXT,                -- メッセージ本文
  channel_id TEXT,                -- Slack 生チャンネルID (C0123456)
  user_id    TEXT,                -- Slack 生ユーザーID (U0123456)
  slack_ts   TEXT,                -- Slack メッセージタイムスタンプ
  thread_ts  TEXT,                -- スレッド親メッセージの ts
  created_at TEXT DEFAULT (datetime('now', 'localtime'))
)
```

FTS5 仮想テーブル (`messages_fts`) を AFTER INSERT トリガーで自動同期。

## 使い方

```bash
# SQLite のみ
slack-cli-stream -t TOKEN --log-sqlite /path/to/slack.db

# TSV と SQLite 同時記録
slack-cli-stream -t TOKEN -l /path/to/logs/ --log-sqlite /path/to/slack.db
```

## 変更ファイル

- `bin/slack-cli-stream` — `--log-sqlite` オプション追加
- `lib/sqlite-logger.js` — SQLite 初期化・INSERT 処理 (新規)
- `lib/core.js` — sqlite-logger の呼び出し、data オブジェクトに `slackTs`/`threadTs` 追加
- `package.json` — `better-sqlite3` 依存追加

## Test plan

- [ ] `npm test` が通ること (27 → 48 テスト)
- [ ] `--log-sqlite` 指定で DB ファイルが作成されメッセージが記録されること
- [ ] `-l` と `--log-sqlite` の併用で両方に記録されること
- [ ] `--log-sqlite` 未指定時に既存の TSV ログ動作が変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)