### PR TITLE
Add logging config support in YAML settings file

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -184,16 +184,23 @@ core.start = async (commander) => {
     logger = getLogger(options.debug);
   }
 
-  if (options.logSqlite) {
-    sqliteDb = initSqliteDb(options.logSqlite);
-  }
-
   if (options.settings) {
     util.parseSettingFile(options.settings);
 
     if (util.token) {
       token = util.token;
     }
+
+    if (!options.log && util.logging.file) {
+      options.log = util.logging.file;
+    }
+    if (!options.logSqlite && util.logging.sqlite) {
+      options.logSqlite = util.logging.sqlite;
+    }
+  }
+
+  if (options.logSqlite) {
+    sqliteDb = initSqliteDb(options.logSqlite);
   }
 
   const {RTMClient} = require("@slack/client");

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -18,6 +18,7 @@ let initialize = () => {
   utility.theme = {};
   utility.twitter = {};
   utility.openai_api_token = "";
+  utility.logging = {};
 };
 
 initialize();
@@ -163,6 +164,16 @@ utility.parseSettingFile = (path) => {
 
   if (settings.openai_api_key) {
     utility.openai_api_key = settings.openai_api_key;
+  }
+
+  utility.logging = {};
+  if (settings.logging) {
+    if (settings.logging.file) {
+      utility.logging.file = settings.logging.file;
+    }
+    if (settings.logging.sqlite) {
+      utility.logging.sqlite = settings.logging.sqlite;
+    }
   }
 };
 

--- a/test/settings_sample.yaml
+++ b/test/settings_sample.yaml
@@ -31,4 +31,7 @@ twitter:
   consumer_secret: CONSUMER_SECRET_SAMPLE
   access_token_key: ACCESS_TOKEN_KEY_SAMPLE
   access_token_secret: ACCESS_TOKEN_SECRET_SAMPLE
+logging:
+  file: ./logs
+  sqlite: ./logs/slack.db
 


### PR DESCRIPTION
## Summary

- YAMLの `logging` セクションで `file` / `sqlite` を指定できるように追加
- CLIオプション未指定時にYAML設定が自動で適用される
- CLIオプションが明示された場合はそちらが優先される

## 設定例

```yaml
logging:
  file: ./logs            # --log に相当
  sqlite: ./logs/slack.db # --log-sqlite に相当
```

これにより起動コマンドからログ関連オプションを省略できる：

```bash
node bin/slack-cli-stream --settings ~/pepabo-slack.yaml
```

## Test plan

- [ ] `npm test` が全48テスト通過することを確認
- [ ] YAMLに `logging.sqlite` を設定してオプションなしで起動し、SQLiteにログが記録されることを確認
- [ ] CLIオプション (`--log-sqlite`) を明示した場合、YAMLより優先されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)