### PR TITLE
Refactor: remove Twitter integration and clean up unused code

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -5,7 +5,6 @@ let emoji = require("node-emoji");
 let winston = require("winston");
 let util = require("./utility.js");
 let cli = require("./cli.js");
-let twitter = require("twitter");
 
 const path = require("path");
 const fs = require("fs");
@@ -14,17 +13,15 @@ const { initSqliteDb, logMessageSqlite } = require("./sqlite-logger");
 
 let sqliteDb = null;
 
-let getLogger = (path) => {
-  let settings = {
+let getLogger = (filePath) => {
+  return winston.createLogger({
     transports: [
-      new winston.transports.File({ filename: path, json: true})
+      new winston.transports.File({ filename: filePath })
     ],
     exceptionHandlers: [
-      new winston.transports.File({ filename: path, json: true})
+      new winston.transports.File({ filename: filePath })
     ]
-  };
-
-  return new (winston.Logger)(settings);
+  });
 };
 
 // ログファイルにメッセージを記録する関数
@@ -263,44 +260,6 @@ core.start = async (commander) => {
   util.startUp = false;
 
 
-  if (util.twitter) {
-    let lastestTwId=1;
-    let twitterClient = new twitter(util.twitter);
-
-    let collectTweets = () => {
-      twitterClient.get("statuses/home_timeline", {count:30, since_id:lastestTwId}, (error,tweets) => {
-
-        if (error) {
-          console.log(error);
-          return;
-        }
-
-        if (Array.isArray(tweets)) {
-
-          if (tweets.length > 0) {
-            lastestTwId = tweets[0].id;
-            tweets.reverse();
-          }
-
-          tweets.forEach((tweet) => {
-            let data = {
-              bufferKey: "twitter",
-              lines: tweet.text.split(/\n/),
-              time: moment(tweet.created_at),
-              channel: "[Twitter]",
-              user: tweet.user.screen_name
-            };
-
-            core.display(data);
-          });
-        }
-      });
-    };
-
-    setInterval(collectTweets, 1000 * 60);
-  }
-
-
   rtm.on("error", (error) => {
     if (error && typeof error === "object") {
       console.error("RTM connection error:", error.message || JSON.stringify(error));
@@ -460,6 +419,24 @@ core.start = async (commander) => {
   if (!Number.isFinite(refreshIntervalMinutes) || refreshIntervalMinutes <= 0) {
     refreshIntervalMinutes = 15;
   }
+  const applyChannels = (channels) => {
+    channels.forEach((v, i) => {
+      v.color = colors[i % colors.length];
+      util.channels[v.id] = v;
+    });
+  };
+
+  const applyUsers = (members) => {
+    if (!Array.isArray(members)) return;
+    members.forEach((v, i) => {
+      v.color = colors[i % colors.length];
+      if (!v.name) {
+        v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
+      }
+      util.users[v.id] = v;
+    });
+  };
+
   const refreshSlackData = async () => {
     if (isRefreshing) {
       return;
@@ -467,57 +444,29 @@ core.start = async (commander) => {
     isRefreshing = true;
     try {
       let response = await web.conversations.list({
-        limit:1000,
+        limit: 1000,
         types: "public_channel,private_channel,im,mpim"
       });
+      applyChannels(response.channels);
 
-      response.channels.forEach((v, i) => {
-        v.color = colors[i % colors.length];
-        util.channels[v.id] = v;
-      });
-
-      while(response.response_metadata.next_cursor != "") {
+      while (response.response_metadata.next_cursor != "") {
         response = await web.conversations.list({
           limit: 1000,
           types: "public_channel,private_channel,im,mpim",
           cursor: response.response_metadata.next_cursor
         });
-
-        response.channels.forEach((v, i) => {
-          v.color = colors[i % colors.length];
-          util.channels[v.id] = v;
-        });
+        applyChannels(response.channels);
       }
 
       response = await web.users.list();
-      
-      if (response.members && Array.isArray(response.members)) {
-        response.members.forEach((v, i) => {
-          v.color = colors[i % colors.length];
-          // nameプロパティが存在しない場合の代替案を追加
-          if (!v.name) {
-            v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
-          }
-          util.users[v.id] = v;
-        });
-      }
+      applyUsers(response.members);
 
-      while(response.response_metadata && response.response_metadata.next_cursor != "") {
+      while (response.response_metadata && response.response_metadata.next_cursor != "") {
         response = await web.users.list({
           limit: 1000,
           cursor: response.response_metadata.next_cursor
         });
-
-        if (response.members && Array.isArray(response.members)) {
-          response.members.forEach((v, i) => {
-            v.color = colors[i % colors.length];
-            // nameプロパティが存在しない場合の代替案を追加
-            if (!v.name) {
-              v.name = v.real_name || (v.profile && v.profile.display_name) || v.id;
-            }
-            util.users[v.id] = v;
-          });
-        }
+        applyUsers(response.members);
       }
     } catch (error) {
       console.error("Failed to refresh Slack metadata:", error.message || error);

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -16,8 +16,6 @@ let initialize = () => {
   utility.hooks = [];
   utility.buffer = {};
   utility.theme = {};
-  utility.twitter = {};
-  utility.openai_api_token = "";
   utility.logging = {};
 };
 
@@ -153,17 +151,6 @@ utility.parseSettingFile = (path) => {
     if (settings.theme.date) {
       utility.theme.date = settings.theme.date;
     }
-  }
-
-  utility.twitter = false;
-  if (settings.twitter) {
-    if (settings.twitter.consumer_key && settings.twitter.consumer_secret && settings.twitter.access_token_key && settings.twitter.access_token_secret) {
-      utility.twitter = settings.twitter;
-    }
-  }
-
-  if (settings.openai_api_key) {
-    utility.openai_api_key = settings.openai_api_key;
   }
 
   utility.logging = {};

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "moment": "^2.29.4",
     "nconf": "^0.12.0",
     "node-emoji": "^1.11.0",
-    "shell": "^0.8.5",
     "sprintf-js": "^1.1.2",
-    "twitter": "^1.1.0",
     "winston": "^3.8.2"
   },
   "devDependencies": {

--- a/test/settings_sample.yaml
+++ b/test/settings_sample.yaml
@@ -26,11 +26,6 @@ hooks:
     user: hideack
     cron: "58 23 * * *"
     hook: cron test
-twitter:
-  consumer_key: CONSUMER_KEY_SAMPLE
-  consumer_secret: CONSUMER_SECRET_SAMPLE
-  access_token_key: ACCESS_TOKEN_KEY_SAMPLE
-  access_token_secret: ACCESS_TOKEN_SECRET_SAMPLE
 logging:
   file: ./logs
   sqlite: ./logs/slack.db

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -100,23 +100,6 @@ describe("設定ファイル読み込みのテスト", () => {
     assert.equal(util.theme.date, "red", "日付の表示用色指定が読み込めている");
   });
 
-  describe("twitter設定読み込みのテスト", () => {
-    it("twitterの設定が無いYAMLファイルの場合、util.twitterのプロパティがfalseになっていること", () => {
-      util.parseSettingFile('./test/settings_sample_without_twitter.yaml');
-      assert.equal(util.twitter, false, "util.twitterのプロパティがfalse");
-    });
-
-    it("正しいYAMLファイルの場合、consumer keyが読めていること", () => {
-      util.parseSettingFile('./test/settings_sample.yaml');
-      assert.equal(util.twitter.consumer_key, "CONSUMER_KEY_SAMPLE", "サンプルの設定が読めている (consumer key)");
-    });
-
-    it("誤ったYAMLファイルの場合、util.twitterのプロパティがfalseになっていること", () => {
-      util.parseSettingFile('./test/settings_sample_invalid_twitter.yaml');
-      assert.equal(util.twitter, false, "util.twitterのプロパティがfalse");
-    });
-  });
-
   describe("hooks定義読み取りのテスト", () => {
     beforeEach( () => {
       util.parseSettingFile('./test/settings_sample.yaml');


### PR DESCRIPTION
## Summary

- Twitter連携を完全削除 (`lib/core.js`, `lib/utility.js`, テスト, サンプルYAML) — X側のAPI仕様変更で稼働していないため
- 未使用の依存パッケージを削除 (`twitter`, `shell`)
- 未実装のまま残っていた `openai_api_token` を削除
- `getLogger` を旧Winston API (`new winston.Logger`) から `winston.createLogger` に修正
- `refreshSlackData` 内のチャンネル・ユーザー取得ループを `applyChannels` / `applyUsers` に共通化し重複を解消

## 変更規模

5 files changed, 30 insertions(+), 118 deletions(-)

## Test plan

- [x] `npm test` 全45テスト通過を確認
- [ ] `npm install` で `twitter` / `shell` パッケージが削除されること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)