### PR TITLE
Fix RTM reconnection failure after PC resume

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -280,6 +280,35 @@ core.start = async (commander) => {
   });
 
   let isReconnecting = false;
+  let rtmRestartAttempts = 0;
+  const RTM_RESTART_BASE_DELAY_MS = 5000;
+  const RTM_RESTART_MAX_DELAY_MS = 60000;
+
+  function scheduleRtmRestart() {
+    const delay = Math.min(
+      RTM_RESTART_BASE_DELAY_MS * Math.pow(2, rtmRestartAttempts),
+      RTM_RESTART_MAX_DELAY_MS
+    );
+    rtmRestartAttempts++;
+    console.log(`Retrying RTM connection in ${delay / 1000}s... (attempt ${rtmRestartAttempts})`);
+    setTimeout(() => {
+      rtm.start();
+    }, delay);
+  }
+
+  function isNetworkError(error) {
+    if (!error) return false;
+    const msg = error.message || String(error);
+    return (
+      error.code === "ENOTFOUND" ||
+      error.code === "ECONNREFUSED" ||
+      error.code === "ETIMEDOUT" ||
+      msg.includes("ENOTFOUND") ||
+      msg.includes("ECONNREFUSED") ||
+      msg.includes("ETIMEDOUT") ||
+      msg.includes("getaddrinfo")
+    );
+  }
 
   rtm.on("disconnect", () => {
     if (!isReconnecting) {
@@ -295,11 +324,12 @@ core.start = async (commander) => {
   });
 
   rtm.on("authenticated", (rtmStartData) => {
+    rtmRestartAttempts = 0;
     if (isReconnecting) {
       console.log("RTM reconnected successfully");
       isReconnecting = false;
     }
-    
+
     if (!util.startUp) {
       console.log(
         `Logged in as ${chalk.bold(rtmStartData.self.name)} of team ${chalk.green.bold(rtmStartData.team.name)}, but not yet connected to a channel`
@@ -311,6 +341,9 @@ core.start = async (commander) => {
   rtm.on("unable_to_rtm_start", (error) => {
     console.error("Unable to start RTM:", error.message || error);
     isReconnecting = false;
+    if (isNetworkError(error)) {
+      scheduleRtmRestart();
+    }
   });
 
   rtm.on("message", (message) => {


### PR DESCRIPTION
## Summary

- PC のスリープ復帰後にネットワークが即座に利用できない場合、`ENOTFOUND slack.com` エラーで RTM クライアント組み込みのリトライが尽きると `unable_to_rtm_start` が発火し、以後接続が復旧しない問題を修正

## 変更内容

- `isNetworkError()` ヘルパーを追加: `ENOTFOUND` / `ECONNREFUSED` / `ETIMEDOUT` / `getaddrinfo` を含むエラーをネットワークエラーと判定
- `scheduleRtmRestart()` を追加: 指数バックオフ（5s → 10s → 20s → 最大 60s）でリトライをスケジュール
- `unable_to_rtm_start` ハンドラでネットワークエラー検出時に自動リトライを開始
- `authenticated` ハンドラでリトライカウンタをリセット

## 動作

| 状態 | 動作 |
|------|------|
| 復帰直後（ネットワーク未回復） | 5s 後にリトライ、失敗なら 10s、20s、… 最大 60s 間隔で再試行 |
| ネットワーク回復後 | 認証成功でカウンタリセット、通常動作に戻る |
| ネットワーク以外のエラー | 従来通りログのみ（リトライなし） |

## Test plan

- [x] スリープ → 復帰後に自動再接続されることを手動確認
- [x] 認証成功後に `rtmRestartAttempts` がリセットされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)