### PR TITLE
Fix process crash on network error during RTM reconnect

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -257,6 +257,25 @@ core.start = async (commander) => {
       return;
     }
     
+    // ネットワークエラー (WebClient.js からの DNS/接続エラー) はリトライ対象
+    if (isNetworkError && isNetworkError(error)) {
+      errorCount++;
+      if (now - lastErrorTime > ERROR_THROTTLE_MS) {
+        if (errorCount > 1) {
+          console.error(`RTM network errors occurred (${errorCount} times since last report)`);
+        } else {
+          console.error("RTM network error caught:", error.message || "Unknown network error");
+        }
+        lastErrorTime = now;
+        errorCount = 0;
+      }
+      if (!isReconnecting) {
+        isReconnecting = true;
+        scheduleRtmRestart();
+      }
+      return;
+    }
+
     // その他の予期しないエラーは通常通り処理
     throw error;
   });


### PR DESCRIPTION
## Summary

- `uncaughtException` ハンドラが `RTMClient.js` 由来のエラーしか握りつぶしておらず、`WebClient.js` から来る `ENOTFOUND` などの DNS/ネットワークエラーが `throw` されてプロセスがクラッシュしていた問題を修正
- `isNetworkError()` で判定し、ネットワークエラーの場合は `scheduleRtmRestart()` を呼んで既存の exponential backoff リトライ処理に繋げるよう変更
- PC スリープ復帰後にネットワークが戻るまで、プロセスを落とさずリトライし続けるようになる

## 再現ケース

PC スリープ復帰直後、RTM 再接続リトライを2〜3回繰り返した後に以下のエラーでプロセスが終了していた：

```
Unable to start RTM: A request error occurred: getaddrinfo ENOTFOUND slack.com
Retrying RTM connection in 5s... (attempt 1)
Unable to start RTM: A request error occurred: getaddrinfo ENOTFOUND slack.com
Retrying RTM connection in 10s... (attempt 2)
Error: A request error occurred: getaddrinfo ENOTFOUND slack.com
    at WebClient.<anonymous> (/.../@slack/client/dist/WebClient.js:578:31)
```

## Test plan

- [ ] PC スリープ → 復帰後もプロセスが落ちずに RTM 再接続が成功することを確認
- [ ] ネットワーク断 → 復旧後に自動再接続されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)