### PR TITLE
Log full message lines without snip truncation

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -144,10 +144,22 @@ core.display = (data, options)  => {
       l
     );
 
-    if (options.log || options.logSqlite) {
-      const plainDateFormat = removeEscapeSequences(dateFormat);
-      const plainChannel = removeEscapeSequences(channel);
-      const plainName = removeEscapeSequences(name);
+    name = chalk.white("|>");
+  });
+
+  if (options && (options.log || options.logSqlite)) {
+    const plainDateFormat = data.time.format("YYYY-MM-DD HH:mm:ss");
+    const plainChannel = removeEscapeSequences(channel);
+    const plainName = removeEscapeSequences(
+      util.users[data.user]
+        ? chalk[util.users[data.user].color](util.users[data.user].name)
+        : (typeof data.user === "string" ? data.user : "-")
+    );
+
+    (data.fullLines || data.lines).forEach((line) => {
+      let l = emoji.emojify(line);
+      l = util.replaceSlackId(l);
+      l = util.decolateText(l);
       const plainLine = removeEscapeSequences(l);
 
       if (options.log) {
@@ -166,10 +178,8 @@ core.display = (data, options)  => {
           data.threadTs || null
         );
       }
-    }
-
-    name = chalk.white("|>");
-  });
+    });
+  }
 };
 
 core.start = async (commander) => {
@@ -421,6 +431,7 @@ core.start = async (commander) => {
       }
     }
 
+    let fullLines = lines;
     if (lines.length > 8) {
       lines = lines.slice(0, 5);
       lines.push("--- snip ---");
@@ -438,6 +449,7 @@ core.start = async (commander) => {
     let data = {
       bufferKey: (typeof message.channel == "string") ? resolveChannelLabelKey(message.channel) : "-",
       lines: lines,
+      fullLines: fullLines,
       time: time,
       channel: message.channel,
       user: message.user,


### PR DESCRIPTION
## Summary

- コンソール表示では引き続き8行超のメッセージをsnip（5行+`--- snip ---`）
- ファイルログ（`--log`）およびSQLiteログ（`--log-sqlite`）には全行を記録するよう修正

## 変更内容

- snip処理の前に `fullLines` として全行を保持
- `data` オブジェクトに `fullLines` フィールドを追加
- `core.display` のログ記録ループをコンソール表示ループから分離し、`data.fullLines` を使用

## Test plan

- [x] 8行を超える長いメッセージを受信し、コンソールがsnipされることを確認
- [x] 同メッセージがログファイル/SQLiteに全行記録されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)