### PR TITLE
Remove noisy RTM WebSocket error log messages

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -241,11 +241,6 @@ core.start = async (commander) => {
     if (error && error.stack && error.stack.includes("RTMClient.js")) {
       errorCount++;
       if (now - lastErrorTime > ERROR_THROTTLE_MS) {
-        if (errorCount > 1) {
-          console.error(`RTM WebSocket errors occurred (${errorCount} times since last report)`);
-        } else {
-          console.error("RTM WebSocket error caught:", error.message || "Unknown RTM error");
-        }
         lastErrorTime = now;
         errorCount = 0;
       }


### PR DESCRIPTION
## Summary

- RTMClient.js のエラーハンドラ内にあった `RTM WebSocket errors occurred (N times since last report)` および `RTM WebSocket error caught: ...` のログ出力を削除
- スロットリング処理自体は維持

## Test plan

- [x] RTM接続中にWebSocketエラーが発生しても、不要なログが出力されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)