### PR TITLE
Add prefix matching support for hooks

### DIFF
--- a/lib/utility.js
+++ b/lib/utility.js
@@ -66,7 +66,9 @@ utility.hasHooks = (message) => {
   for(let i=0; i<utility.hooks.length; i++) {
     let hook = utility.hooks[i];
 
-    if (typeof hook.keyword === "undefined" || hook.keyword == message.text) {
+    const keywordMatch = typeof hook.keyword === "undefined" || hook.keyword == message.text;
+    const prefixMatch = typeof hook.prefix === "undefined" || (typeof message.text === "string" && message.text.startsWith(hook.prefix));
+    if (keywordMatch && prefixMatch) {
       if (!utility.users[message.user]) continue;
 
       if (hook.user) {

--- a/test/settings_sample.yaml
+++ b/test/settings_sample.yaml
@@ -26,6 +26,11 @@ hooks:
     user: hideack
     cron: "58 23 * * *"
     hook: cron test
+  -
+    user: hideack
+    channel: times_hideack
+    prefix: "!deploy"
+    hook: echo DEPLOY
 logging:
   file: ./logs
   sqlite: ./logs/slack.db

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -112,7 +112,7 @@ describe("設定ファイル読み込みのテスト", () => {
     });
 
     it("複数のhook定義が入っていること(但しhookの定義がないものは除外される)", () => {
-      assert.equal(util.hooks.length, 4, "4件分の定義が存在すること");
+      assert.equal(util.hooks.length, 5, "5件分の定義が存在すること");
     });
 
     it("1件目の定義に必要な設定が読み取られていること", () => {
@@ -143,6 +143,16 @@ describe("設定ファイル読み込みのテスト", () => {
     it("cronとしてセットした時間(12:00)より前なのでcron入れたhookは反応しないこと", () =>{
       let message = {type: 'message', channel: 'XXEGEXXS0', user: 'XX3NKUBXX', text: 'slack', ts: '1563587208.0006',source_team: 'XXYGLB4ZZ', team: 'ZZ3GLB4XX' };
       assert.deepEqual(util.hasHooks(message), ["echo HOGE"], "userが一致したためhookさせるコマンドが1つ返る");
+    });
+
+    it("prefixが一致したらhookさせるコマンドが返ること", () => {
+      let message = {type: 'message', channel: 'XXEGEXXS0', user: 'XX3NKUBXX', text: '!deploy production', ts: '1563587208.0006', source_team: 'XXYGLB4ZZ', team: 'ZZ3GLB4XX' };
+      assert.include(util.hasHooks(message), "echo DEPLOY", "prefixが一致したためhookさせるコマンドが返る");
+    });
+
+    it("prefixが一致しない場合はhookが反応しないこと", () => {
+      let message = {type: 'message', channel: 'XXEGEXXS0', user: 'XX3NKUBXX', text: 'hello world', ts: '1563587208.0006', source_team: 'XXYGLB4ZZ', team: 'ZZ3GLB4XX' };
+      assert.notInclude(util.hasHooks(message), "echo DEPLOY", "prefixが一致しないためhookが反応しない");
     });
   });
 });


### PR DESCRIPTION
## Summary

- `hooks` 設定に `prefix` フィールドを追加し、特定の文字列で始まるメッセージに対してコマンドを発火できるようにした
- 既存の `keyword`（完全一致）との AND 条件として動作する
- `keyword` と `prefix` を同時指定した場合は両方の条件を満たすメッセージのみ反応する

## 設定例

```yaml
hooks:
  - user: hideack
    channel: general
    prefix: "!deploy"
    hook: /path/to/deploy.sh
```

## Test plan

- [x] `npm test` 全55件パス
- [x] `prefix` が一致した場合にコマンドが返ること
- [x] `prefix` が一致しない場合にコマンドが返らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)