### PR TITLE
バックフィル完了時にチャンネル別補完メッセージ数をサマリー表示

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -568,6 +568,7 @@ core.start = async (commander) => {
       let processedChannels = 0;
       let earliestTs = null;
       let latestTs = null;
+      const fetchedPerChannel = {};
       const CONCURRENCY = 5;
 
       const processMessage = (message, channelId) => {
@@ -632,6 +633,7 @@ core.start = async (commander) => {
         });
 
         totalFetched++;
+        fetchedPerChannel[channelId] = (fetchedPerChannel[channelId] || 0) + 1;
 
         const ts = parseFloat(message.ts);
         if (earliestTs === null || ts < earliestTs) earliestTs = ts;
@@ -676,6 +678,11 @@ core.start = async (commander) => {
         clearInterval(progressInterval);
         if (totalFetched > 0) {
           process.stdout.write(`Backfill complete: ${totalFetched} message(s) fetched.\n`);
+          Object.entries(fetchedPerChannel)
+            .sort((a, b) => b[1] - a[1])
+            .forEach(([chId, count]) => {
+              process.stdout.write(`  ${resolveChannelLabelKey(chId)}: ${count} message(s)\n`);
+            });
         } else {
           process.stdout.write("Backfill complete: no new messages.\n");
         }


### PR DESCRIPTION
## Summary

- バックフィル完了メッセージ (`Backfill complete: N message(s) fetched.`) の直後に、チャンネル別の補完メッセージ数を多い順に1行ずつ表示するようにした
- チャンネルIDではなくチャンネル名 (`resolveChannelLabelKey`) で表示

## 出力例

```
Backfill complete: 89 message(s) fetched.
  general: 45 message(s)
  random: 30 message(s)
  dev: 14 message(s)
```

## Test plan

- [ ] 既存テスト (`npm test`) がすべて通ることを確認
- [ ] 実際のバックフィル実行時に上記フォーマットでサマリーが出力されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)