### PR TITLE
レジューム時のバックフィル実装 (タイマードリフト検出)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -555,15 +555,20 @@ core.start = async (commander) => {
   await refreshSlackData();
   setInterval(refreshSlackData, refreshIntervalMinutes * 60 * 1000);
 
-  // 起動時差分バックフィル: 前回停止からのギャップが閾値を超えた場合のみ実行
-  if (sqliteDb && backfillGapSeconds !== null && backfillGapSeconds > BACKFILL_GAP_THRESHOLD) {
-    const lastTsMap = getLastSlackTsPerChannel(sqliteDb);
-    // 過去24時間以内に活動があったチャンネルのみ対象にすることで呼び出し数を抑制
-    const cutoff = Date.now() / 1000 - 24 * 3600;
-    const channelIds = Object.keys(lastTsMap).filter(id => parseFloat(lastTsMap[id]) > cutoff);
+  let isBackfilling = false;
 
-    if (channelIds.length > 0) {
-      process.stdout.write(`Backfilling messages for ${channelIds.length} channel(s) in background...\n`);
+  const runBackfill = async (label) => {
+    if (isBackfilling || !sqliteDb) return;
+    isBackfilling = true;
+    try {
+      const lastTsMap = getLastSlackTsPerChannel(sqliteDb);
+      // 過去24時間以内に活動があったチャンネルのみ対象にすることで呼び出し数を抑制
+      const cutoff = Date.now() / 1000 - 24 * 3600;
+      const channelIds = Object.keys(lastTsMap).filter(id => parseFloat(lastTsMap[id]) > cutoff);
+
+      if (channelIds.length === 0) return;
+
+      process.stdout.write(`${label} Backfilling messages for ${channelIds.length} channel(s) in background...\n`);
       let totalFetched = 0;
       let processedChannels = 0;
       let earliestTs = null;
@@ -662,32 +667,55 @@ core.start = async (commander) => {
         processedChannels++;
       };
 
-      // バックグラウンドで実行 (RTM の起動を待たせない)
-      (async () => {
-        const progressInterval = setInterval(() => {
-          const range = earliestTs
-            ? `${moment(earliestTs * 1000).format("YYYY-MM-DD HH:mm")} 〜 ${moment(latestTs * 1000).format("YYYY-MM-DD HH:mm")}`
-            : "no messages yet";
-          process.stdout.write(`Backfill progress: ${processedChannels}/${channelIds.length} channels, time range: ${range}\n`);
-        }, 60 * 1000);
+      const progressInterval = setInterval(() => {
+        const range = earliestTs
+          ? `${moment(earliestTs * 1000).format("YYYY-MM-DD HH:mm")} 〜 ${moment(latestTs * 1000).format("YYYY-MM-DD HH:mm")}`
+          : "no messages yet";
+        process.stdout.write(`Backfill progress: ${processedChannels}/${channelIds.length} channels, time range: ${range}\n`);
+      }, 60 * 1000);
 
-        for (let i = 0; i < channelIds.length; i += CONCURRENCY) {
-          await Promise.all(channelIds.slice(i, i + CONCURRENCY).map(fetchChannel));
-        }
+      for (let i = 0; i < channelIds.length; i += CONCURRENCY) {
+        await Promise.all(channelIds.slice(i, i + CONCURRENCY).map(fetchChannel));
+      }
 
-        clearInterval(progressInterval);
-        if (totalFetched > 0) {
-          process.stdout.write(`Backfill complete: ${totalFetched} message(s) fetched.\n`);
-          Object.entries(fetchedPerChannel)
-            .sort((a, b) => b[1] - a[1])
-            .forEach(([chId, count]) => {
-              process.stdout.write(`  ${resolveChannelLabelKey(chId)}: ${count} message(s)\n`);
-            });
-        } else {
-          process.stdout.write("Backfill complete: no new messages.\n");
-        }
-      })();
+      clearInterval(progressInterval);
+      if (totalFetched > 0) {
+        process.stdout.write(`Backfill complete: ${totalFetched} message(s) fetched.\n`);
+        Object.entries(fetchedPerChannel)
+          .sort((a, b) => b[1] - a[1])
+          .forEach(([chId, count]) => {
+            process.stdout.write(`  ${resolveChannelLabelKey(chId)}: ${count} message(s)\n`);
+          });
+      } else {
+        process.stdout.write("Backfill complete: no new messages.\n");
+      }
+    } finally {
+      isBackfilling = false;
     }
+  };
+
+  // 起動時差分バックフィル: 前回停止からのギャップが閾値を超えた場合のみ実行
+  if (sqliteDb && backfillGapSeconds !== null && backfillGapSeconds > BACKFILL_GAP_THRESHOLD) {
+    // バックグラウンドで実行 (RTM の起動を待たせない)
+    runBackfill("[Startup]").catch(() => {});
+  }
+
+  // レジューム検出: タイマードリフトでスリープからの復帰を検知し、5分以上経過していればバックフィル発動
+  if (sqliteDb) {
+    const SLEEP_DETECT_INTERVAL_MS = 30 * 1000;
+    const RESUME_THRESHOLD_MS = BACKFILL_GAP_THRESHOLD * 1000;
+    let lastSleepCheckAt = Date.now();
+
+    setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - lastSleepCheckAt;
+      lastSleepCheckAt = now;
+
+      if (elapsed > RESUME_THRESHOLD_MS) {
+        process.stdout.write("System resume detected. Running backfill...\n");
+        runBackfill("[Resume]").catch(() => {});
+      }
+    }, SLEEP_DETECT_INTERVAL_MS);
   }
 
   // complete


### PR DESCRIPTION
## Summary

- PCがスリープからレジュームした際、5分以上経過していた場合にバックフィルを自動発動する機能を追加
- JavaScript のタイマードリフト検出（30秒間隔の `setInterval` で実経過時間を計測）を利用。スリープ中はタイマーが停止するため、予想より大幅に遅れて発火した場合にレジュームと判定する
- 追加の npm パッケージなし、macOS / Linux どちらでも動作

## Changes

- 既存の起動時バックフィルのインラインブロックを `runBackfill(label)` 関数に抽出し、起動時・レジューム時で共通利用できるようにした
- `isBackfilling` フラグで二重実行を防止（起動時バックフィルとレジューム検出が競合しない）
- ログ出力に `[Startup]` / `[Resume]` ラベルを付けてどちらの経路か区別できるようにした

## Detection mechanism

```
30秒ごとのタイマーが実際には5分以上後に発火
  → elapsed > RESUME_THRESHOLD_MS (5 * 60 * 1000)
  → "System resume detected. Running backfill..." を出力
  → runBackfill("[Resume]") を実行
```

## Test plan

- [ ] `--log-sqlite` オプション付きで起動し、PCをスリープ → 5分以上後にレジューム → "System resume detected. Running backfill..." が表示されることを確認
- [ ] バックフィル実行中に再度レジュームしても二重実行されないことを確認（`isBackfilling` フラグ）
- [ ] `--log-sqlite` なしの場合はレジューム検出ブロック自体がスキップされることを確認
- [ ] 起動時バックフィル（既存動作）が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)