### PR TITLE
バックフィル改善: --backfill-from オプション追加・カットオフバグ修正・進捗表示改善

### DIFF
--- a/bin/slack-cli-stream
+++ b/bin/slack-cli-stream
@@ -26,6 +26,7 @@ program
   .option("--refresh-interval <minutes>", "Refresh Slack metadata interval in minutes (default: 15)")
   .option("--mcp-port <port>", "Enable MCP server on the given port (e.g. 3737)")
   .option("--status", "Show Slack usage status for the past week and exit")
+  .option("--backfill-from <datetime>", "Force backfill from the specified date/time (e.g. \"2026-05-28\" or \"2026-05-28 09:00\")")
   .usage("[options] <parameters>")
   .parse(process.argv);
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -209,11 +209,23 @@ core.start = async (commander) => {
 
   const BACKFILL_GAP_THRESHOLD = 5 * 60; // 5分以上のギャップがあればバックフィルを実行
   let backfillGapSeconds = null;
+  let lastHeartbeatTs = null; // 前回ハートビートのUnixタイムスタンプ(秒)
+
+  let forceSince = null; // --backfill-from で指定された開始時刻(Unixタイムスタンプ秒)
+  if (options.backfillFrom) {
+    const parsed = moment(options.backfillFrom, ["YYYY-MM-DD HH:mm", "YYYY-MM-DD"], true);
+    if (!parsed.isValid()) {
+      console.error(`Error: --backfill-from の日時形式が不正です: "${options.backfillFrom}" (例: "2026-05-28" または "2026-05-28 09:00")`);
+      process.exit(1);
+    }
+    forceSince = parsed.unix();
+  }
 
   if (options.logSqlite) {
     sqliteDb = initSqliteDb(options.logSqlite);
     const lastHeartbeat = getLastAppHeartbeat(sqliteDb);
     if (lastHeartbeat !== null) {
+      lastHeartbeatTs = lastHeartbeat;
       backfillGapSeconds = Date.now() / 1000 - lastHeartbeat;
     }
     updateAppHeartbeat(sqliteDb);
@@ -557,18 +569,30 @@ core.start = async (commander) => {
 
   let isBackfilling = false;
 
-  const runBackfill = async (label) => {
+  const runBackfill = async (label, manualSince) => {
     if (isBackfilling || !sqliteDb) return;
     isBackfilling = true;
     try {
       const lastTsMap = getLastSlackTsPerChannel(sqliteDb);
-      // 過去24時間以内に活動があったチャンネルのみ対象にすることで呼び出し数を抑制
-      const cutoff = Date.now() / 1000 - 24 * 3600;
-      const channelIds = Object.keys(lastTsMap).filter(id => parseFloat(lastTsMap[id]) > cutoff);
+
+      let channelIds;
+      if (manualSince !== undefined && manualSince !== null) {
+        // 手動バックフィル: カットオフフィルターをスキップして全チャンネルを対象にする
+        channelIds = Object.keys(lastTsMap);
+      } else {
+        // 前回ハートビート時刻を基準に24時間前をカットオフとする。
+        // 固定の「現在-24h」にすると停止期間が24h超の場合に全チャンネルが除外されるため。
+        const anchor = lastHeartbeatTs !== null ? lastHeartbeatTs : Date.now() / 1000;
+        const cutoff = anchor - 24 * 3600;
+        channelIds = Object.keys(lastTsMap).filter(id => parseFloat(lastTsMap[id]) > cutoff);
+      }
 
       if (channelIds.length === 0) return;
 
-      process.stdout.write(`${label} Backfilling messages for ${channelIds.length} channel(s) in background...\n`);
+      const sinceLabel = manualSince !== undefined && manualSince !== null
+        ? ` from ${moment(manualSince * 1000).format("YYYY-MM-DD HH:mm")}`
+        : "";
+      process.stdout.write(`${label} Backfilling messages for ${channelIds.length} channel(s)${sinceLabel} in background...\n`);
       let totalFetched = 0;
       let processedChannels = 0;
       let earliestTs = null;
@@ -645,14 +669,25 @@ core.start = async (commander) => {
         if (latestTs === null   || ts > latestTs)   latestTs   = ts;
       };
 
+      const printProgress = () => {
+        const pct = Math.round(processedChannels / channelIds.length * 100);
+        process.stdout.write(
+          `Backfill progress: ${processedChannels}/${channelIds.length} channels (${pct}%), ${totalFetched} messages fetched\n`
+        );
+      };
+
       const fetchChannel = async (channelId) => {
-        const lastTs = lastTsMap[channelId];
+        const dbLastTs = lastTsMap[channelId];
+        // 手動指定時: max(manualSince, dbLastTs) で重複挿入を防ぐ
+        const oldest = (manualSince !== undefined && manualSince !== null)
+          ? (dbLastTs && parseFloat(dbLastTs) > manualSince ? dbLastTs : String(manualSince))
+          : dbLastTs;
         let cursor;
         let channelMessages = [];
 
         try {
           do {
-            const params = { channel: channelId, oldest: lastTs, limit: 200 };
+            const params = { channel: channelId, oldest, limit: 200 };
             if (cursor) params.cursor = cursor;
             const res = await web.conversations.history(params);
             channelMessages = channelMessages.concat(res.messages || []);
@@ -667,15 +702,11 @@ core.start = async (commander) => {
         processedChannels++;
       };
 
-      const progressInterval = setInterval(() => {
-        const range = earliestTs
-          ? `${moment(earliestTs * 1000).format("YYYY-MM-DD HH:mm")} 〜 ${moment(latestTs * 1000).format("YYYY-MM-DD HH:mm")}`
-          : "no messages yet";
-        process.stdout.write(`Backfill progress: ${processedChannels}/${channelIds.length} channels, time range: ${range}\n`);
-      }, 60 * 1000);
+      const progressInterval = setInterval(printProgress, 30 * 1000);
 
       for (let i = 0; i < channelIds.length; i += CONCURRENCY) {
         await Promise.all(channelIds.slice(i, i + CONCURRENCY).map(fetchChannel));
+        printProgress();
       }
 
       clearInterval(progressInterval);
@@ -694,9 +725,15 @@ core.start = async (commander) => {
     }
   };
 
-  // 起動時差分バックフィル: 前回停止からのギャップが閾値を超えた場合のみ実行
-  if (sqliteDb && backfillGapSeconds !== null && backfillGapSeconds > BACKFILL_GAP_THRESHOLD) {
-    // バックグラウンドで実行 (RTM の起動を待たせない)
+  // 手動バックフィル: --backfill-from が指定された場合は強制実行
+  if (sqliteDb && forceSince !== null) {
+    if (!options.logSqlite) {
+      console.error("Error: --backfill-from requires --log-sqlite");
+      process.exit(1);
+    }
+    runBackfill("[Manual]", forceSince).catch(() => {});
+  } else if (sqliteDb && backfillGapSeconds !== null && backfillGapSeconds > BACKFILL_GAP_THRESHOLD) {
+    // 起動時差分バックフィル: 前回停止からのギャップが閾値を超えた場合のみ実行
     runBackfill("[Startup]").catch(() => {});
   }
 
@@ -712,6 +749,7 @@ core.start = async (commander) => {
       lastSleepCheckAt = now;
 
       if (elapsed > RESUME_THRESHOLD_MS) {
+        lastHeartbeatTs = (now - elapsed) / 1000;
         process.stdout.write("System resume detected. Running backfill...\n");
         runBackfill("[Resume]").catch(() => {});
       }


### PR DESCRIPTION
## Summary

- **カットオフバグ修正**: バックフィルの対象チャンネル絞り込みを「現在-24h」から「前回ハートビート-24h」に変更。停止期間が24時間を超えると全チャンネルが除外されてしまうバグを解消
- **`--backfill-from <datetime>` オプション追加**: 任意の開始時刻を指定して強制バックフィルを実行可能に。プロセスが長期停止していた際の手動回収に対応
- **進捗表示改善**: バッチ(5ch)完了ごとに進捗を出力 + インターバルを60秒→30秒に短縮

## 使い方

```sh
# 昨日分をまるごと回収
node bin/slack-cli-stream --settings pepabo-slack.yaml --backfill-from "2026-05-28"

# 特定時刻から
node bin/slack-cli-stream --settings pepabo-slack.yaml --backfill-from "2026-05-28 09:00"
```

起動すると以下のように表示され、全チャンネルを対象にバックフィルが走る:
```
[Manual] Backfilling messages for N channel(s) from 2026-05-28 00:00 in background...
Backfill progress: 5/120 channels (4%), 312 messages fetched
...
Backfill complete: 8025 message(s) fetched.
```

各チャンネルの `oldest` は `max(指定時刻, DBの最終ts)` で計算するため重複挿入は発生しない。

## Test plan

- [ ] `--backfill-from "YYYY-MM-DD"` 形式で起動し、指定日以降のメッセージが取り込まれること
- [ ] `--backfill-from "YYYY-MM-DD HH:mm"` 形式でも動作すること
- [ ] 不正な日時形式を渡すとエラーメッセージを出して終了すること
- [ ] `--backfill-from` なしの通常起動で既存の自動バックフィル動作が変わらないこと
- [ ] バックフィル進捗がバッチ完了ごとに表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)