### PR TITLE
バックフィルのハング対策とエラー可視化

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -544,8 +544,14 @@ core.start = async (commander) => {
   });
 
   // Setup
-  const {WebClient} = require("@slack/client");
-  const web = new WebClient(token, {logLevel: "error"});
+  const {WebClient, retryPolicies} = require("@slack/client");
+  // デフォルトの retryConfig は tenRetriesInAboutThirtyMinutes のため、
+  // レートリミット(429)を食らうと最大約30分サイレントにリトライし続けてハングする。
+  // バックフィルが固まる原因になるので、上限の短いリトライポリシーに変更する。
+  const web = new WebClient(token, {
+    logLevel: "error",
+    retryConfig: retryPolicies.fiveRetriesInFiveMinutes
+  });
 
   let isRefreshing = false;
   let refreshIntervalMinutes = parseInt(options.refreshInterval, 10);
@@ -642,7 +648,8 @@ core.start = async (commander) => {
       let earliestTs = null;
       let latestTs = null;
       const fetchedPerChannel = {};
-      const CONCURRENCY = 5;
+      // conversations.history はレートリミットが厳しいため同時実行数を抑える。
+      const CONCURRENCY = 2;
 
       const processMessage = (message, channelId) => {
         if (message.subtype) {
@@ -738,6 +745,10 @@ core.start = async (commander) => {
             cursor = res.has_more ? res.response_metadata.next_cursor : null;
           } while (cursor);
         } catch (err) {
+          // エラーを握りつぶすと原因(ratelimited / missing_scope / not_in_channel 等)が
+          // 分からなくなるため、チャンネルラベル付きで出力する。
+          const reason = (err && err.data && err.data.error) || (err && err.code) || (err && err.message) || "unknown";
+          process.stdout.write(`Backfill error on ${resolveChannelLabelKey(channelId)}: ${reason}\n`);
           return;
         }
 


### PR DESCRIPTION
## 背景

起動時バックフィルが `Backfill progress: 0/38 channels (0%), 0 messages fetched` を延々と出力したまま完了せずハングする事象が発生していた。

進捗ログは30秒インターバル(`lib/core.js:749`)とバッチ完了時(`lib/core.js:753`)から出力される。`processedChannels` は成功・失敗どちらでも `fetchChannel` 末尾で必ずインクリメントされるため、これが 0 のまま = 最初のバッチのチャンネルすら1つも完了していない、つまり `web.conversations.history()` の await でハングしていると判断した。

## 原因

- バックフィル用の `web` クライアントが `retryConfig` 未指定で、Slack SDK デフォルトの `tenRetriesInAboutThirtyMinutes` が効いていた。
- `conversations.history` はレートリミットが厳しく、起動時に38チャンネルへ concurrency 5 で一斉に叩くと即 429 を食らい、**約30分サイレントにリトライし続けてハング**していた。
- `fetchChannel` の catch がエラーを握りつぶしており(`return` のみ)、レートリミットなのかスコープ不足なのか原因がログに残らなかった。

## 変更内容

- `web` クライアントのリトライを `retryPolicies.fiveRetriesInFiveMinutes` に短縮し、長時間ハングを防止
- `fetchChannel` の catch でエラー種別(`ratelimited` / `missing_scope` / `not_in_channel` 等)をチャンネルラベル付きで出力
- バックフィルの同時実行数を 5→2 に抑制してレートリミットを踏みにくくする

## テスト

- `npm test`(lint + mocha)全て通過(62 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)